### PR TITLE
Small typo's

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,13 +17,13 @@ features:
   - title: For bespoke websites
     details: A design agnostic starter kit for all your bespoke Statamic sites pushing SEO and a11y best practices.
   - title: Opinionated
-    details: Peak comes bundles with preconfigured tools like Tailwind and AlpineJS so it's easy to use with any design system.
+    details: Peak comes bundled with preconfigured tools like Tailwindcss and AlpineJS so it's easy to use with any design system.
   - title: Page builder
     details: This kit features a very extendible page builder using native Statamic fields, including Bard for long form content.
   - title: SEO
-    details: Peak comes with full blown professional SEO support including tracker support and a built in cookie banner.
+    details: Peak comes with full blown professional SEO support including various tracker support and a built in cookie banner.
   - title: Social Images
-    details: Let your client generate themed custom social images for all entries based on your own Tailwind templates.
+    details: Let your client generate themed custom social images for all entries based on your own templates.
   - title: A lot more
     details: Responsive assets, browser appearance configuration, favicon generation, button system, dark mode support, forms and more.
 footer: '© 2020 - 2021 | Studio 1902'


### PR DESCRIPTION
I noticed you used Tailwind instead of Tailwindcss. Looking at the branding of tailwindcss.com I think the brand name they want to come out with is with the CSS-part. Right? What do you think? Happy to change it back or do a replace-all. 