### PR TITLE
Fix broken LICENSE link in license.md

### DIFF
--- a/docs/other/license.md
+++ b/docs/other/license.md
@@ -1,3 +1,3 @@
 # License
 
-The MIT License (MIT). Please see [License File](https://github.com/studio1902/statamic-peak/blob/main/LICENSE.md) for more information. Statamic itself is commercial software and has its' own license.
+The MIT License (MIT). Please see [License File](https://github.com/studio1902/statamic-peak/blob/main/LICENSE) for more information. Statamic itself is commercial software and has its' own license.


### PR DESCRIPTION
The https://peak.1902.studio/other/license.html page incorrectly linked to the `LICENSE.md` instead of the `LICENSE` file.