### PR TITLE
Update vite.md

### DIFF
--- a/docs/other/vite.md
+++ b/docs/other/vite.md
@@ -54,10 +54,12 @@ export default defineConfig(({ mode }) => {
             }),
             (() => {
                 return useBrowserSync ? VitePluginBrowserSync({
-                    bs: {
-                        proxy: url,
-                        notify: false,
-                        open: 'external',
+                    dev: {
+                        bs: {
+                            proxy: url,
+                            notify: false,
+                            open: 'external',
+                        },
                     },
                 }) : null;
             })()


### PR DESCRIPTION
vite-plugin-browser-sync

Since version 3.0, bs option should be wrapped inside a dev object.