### PR TITLE
Move reload php fpm to before scripts

### DIFF
--- a/docs/other/deployment-script.md
+++ b/docs/other/deployment-script.md
@@ -17,6 +17,9 @@ composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
 
 npm ci
 npm run build
+
+{RELOAD_PHP_FPM}
+
 {SITE_PHP} artisan cache:clear
 {SITE_PHP} artisan config:cache
 {SITE_PHP} artisan route:cache
@@ -25,8 +28,6 @@ npm run build
 {SITE_PHP} artisan statamic:search:update --all
 {SITE_PHP} artisan statamic:static:clear
 {SITE_PHP} artisan statamic:static:warm --queue
-
-{RELOAD_PHP_FPM}
 
 echo "🚀 Application deployed!"
 ```
@@ -47,6 +48,10 @@ $FORGE_COMPOSER install --no-interaction --prefer-dist --optimize-autoloader --n
 
 npm ci
 npm run build
+
+( flock -w 10 9 || exit 1
+    echo 'Restarting FPM...'; sudo -S service $FORGE_PHP_FPM reload ) 9>/tmp/fpmlock
+
 $FORGE_PHP artisan cache:clear
 $FORGE_PHP artisan config:cache
 $FORGE_PHP artisan route:cache
@@ -55,7 +60,4 @@ $FORGE_PHP artisan queue:restart
 $FORGE_PHP artisan statamic:search:update --all
 $FORGE_PHP artisan statamic:static:clear
 $FORGE_PHP artisan statamic:static:warm --queue
-
-( flock -w 10 9 || exit 1
-    echo 'Restarting FPM...'; sudo -S service $FORGE_PHP_FPM reload ) 9>/tmp/fpmlock
 ```


### PR DESCRIPTION
Consider moving the php FPM reload to before the php scripts run, in theory the scripts would still be running with the previous opcache state which could lead to some funky behavior, clearing the opcache first should ensure that any commands are running the new code.

Forge appears to have made this change in their default deployment script already.