### PR TITLE
Using the correct collapse class.

### DIFF
--- a/docs/features/stacks.md
+++ b/docs/features/stacks.md
@@ -37,4 +37,4 @@ You can also use arbitrary values and modifiers like `stack-[5px] md:stack-16`. 
 Read more on stacks in [this post](https://1902.studio/journal/stack-utilities-to-space-page-builder-blocks).
 
 ## Collapse
-If two siblings with the class `stack-collapse` follow each other in a stack, their margins will collapse.
+If two siblings with the class `stack-space-collapse` follow each other in a stack, their margins will collapse.


### PR DESCRIPTION
It looks like in the docs there is a wrong class mentioned `stack-collapse` while `stack-space-collapse` is the correct one. 