### PR TITLE
Update skip to content docs

### DIFF
--- a/docs/features/skip-to-content.md
+++ b/docs/features/skip-to-content.md
@@ -4,6 +4,15 @@ Peak includes a skip to content button which is the first button that pops up wh
 
 > Note: the strings used in the partial are translatable and can be edited in `resources/lang/en/site.php`.
 
+If you need to, you can add additional skip links via the slot of the view or disable the default content link by passing `defaults="false"`.
+
+```
+{{ partial:statamic-peak-tools::navigation/skip_links defaults="false" }}
+    <a href="#search">Search</a>
+    <a href="#contact">Contact</a>
+{{ /partial:statamic-peak-tools::navigation/skip_links }}
+```
+
 The view that is being used to render this is part of the [Tools Addon](/getting-started/addons.html#tools). If you want to make changes to the views from this addon, you can publish them by running:
 
 ```bash


### PR DESCRIPTION
This PR documents the newly added ``skip_links`` partial that allows to add additional skip links or disable the default content link alltogether.

Main PR: https://github.com/studio1902/statamic-peak-tools/pull/24